### PR TITLE
fix(): openapi: remove required `state` from `EVStateChangeEventData`

### DIFF
--- a/openapi/webhook-events.yaml
+++ b/openapi/webhook-events.yaml
@@ -475,7 +475,6 @@ components:
       # See https://github.com/grid-x/cloud-connector/blob/main/docs/api/openapi.yaml
       type: object
       required:
-        - state
         - issuedAt
         - atHome
       properties:


### PR DESCRIPTION
The schema `EVStateChangeEventData` has `state` listed as required, which is not actually listed as a property on the schema. This leads to code generation tools complain about the OpenAPI spec being invalid. This should not be considered a breaking change, because we never actually defined the property to be set on the event.

See https://grid-x.slack.com/archives/C0623530BED/p1773665250547219